### PR TITLE
Fix broken install-mac.sh

### DIFF
--- a/package/install-mac.sh
+++ b/package/install-mac.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-echo "Checking for brew.."
+
+echo "Checking for brew..."
 if ! [ -x "$(command -v brew)" ]; then
 	echo 'Error: brew is not installed!'
 	echo 'Install brew from https://brew.sh'
@@ -14,10 +15,22 @@ else
 	brew install fftw
 fi
 
+plugin_path="${HOME}/Library/Application Support/obs-studio/plugins/spectralizer"
+
 echo "Uninstalling old version"
-rm -rf "/Users/$USER/Library/Application Support/obs-studio/plugins/spectralizer"
-echo "Creating plugin folder"
-mkdir -p "/Users/$USER/Library/Application Support/obs-studio/plugins/spectralizer"
-echo "Moving plugin over"
-mv plugin/* "/Users/$USER/Library/Application Support/obs-studio/plugins/spectralizer"
+rm -rf "${plugin_path}"
+
+echo "Installing plugin"
+(
+	cd plugin || exit
+	for dir in *; do
+		mkdir -p "${plugin_path}/${dir}"
+		cp -R "${dir}"/* "${plugin_path}/${dir}/"
+	done
+)
+
+echo "Bypassing Gatekeeper for the plugin"
+sudo xattr -rd com.apple.quarantine "${plugin_path}/bin/spectralizer.so"
+
 echo "Done!"
+exit 0


### PR DESCRIPTION
* `cp` instead of `mv`
* the operation actually works now; before it wouldn't on newer macOS versions
* include the gatekeeper bypass `xattr` command ... which fixes the eventual next issue after moving works :)

Fixes #17 